### PR TITLE
The test installation into stack install files

### DIFF
--- a/src/Console/InstallReact.php
+++ b/src/Console/InstallReact.php
@@ -20,5 +20,8 @@ trait InstallReact
 
         (new Filesystem)->ensureDirectoryExists(resource_path('js/components/icons'));
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/react/components/icons', resource_path('js/components/icons'));
+
+        (new Filesystem)->ensureDirectoryExists(base_path('tests/Feature/SocialitePlus'));
+        (new Filesystem)->copyDirectory(__DIR__.'/../stubs/tests/Feature/SocialitePlus', base_path('tests/Feature/SocialitePlus'));
     }
 }

--- a/src/Console/InstallVue.php
+++ b/src/Console/InstallVue.php
@@ -20,5 +20,8 @@ trait InstallVue
 
         (new Filesystem)->ensureDirectoryExists(resource_path('js/components/icons'));
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/vue/components/icons', resource_path('js/components/icons'));
+
+        (new Filesystem)->ensureDirectoryExists(base_path('tests/Feature/SocialitePlus'));
+        (new Filesystem)->copyDirectory(__DIR__.'/../stubs/tests/Feature/SocialitePlus', base_path('tests/Feature/SocialitePlus'));
     }
 }

--- a/src/SocialitePlusServiceProvider.php
+++ b/src/SocialitePlusServiceProvider.php
@@ -29,9 +29,6 @@ class SocialitePlusServiceProvider extends ServiceProvider
             (new Filesystem)->ensureDirectoryExists(app_path('Http/Middleware'));
             (new Filesystem)->copyDirectory(__DIR__.'/../stubs/app/Http/Middleware', app_path('Http/Middleware'));
 
-            (new Filesystem)->ensureDirectoryExists(base_path('tests/Feature/SocialitePlus'));
-            (new Filesystem)->copyDirectory(__DIR__.'/../stubs/tests/Feature/SocialitePlus', base_path('tests/Feature/SocialitePlus'));
-
             $this->commands([
                 Console\InstallCommand::class,
             ]);


### PR DESCRIPTION
This pull request includes changes to the `installReact` and `installVue` methods to ensure the creation of a new directory for SocialitePlus tests. Additionally, it removes redundant code from the `boot` method in the `SocialitePlusServiceProvider`.

This fixes a reported issue. When the package is updated the tests get overwritten or recreated. Moving the creation of the test files avoids this issue.

Directory management improvements:

* [`src/Console/InstallReact.php`](diffhunk://#diff-1d47a6aea0a84ba4813334eae3f70a412200869a75d3643527e32bab36c9f824R23-R25): Added code to ensure the creation of the `tests/Feature/SocialitePlus` directory and copy necessary files.
* [`src/Console/InstallVue.php`](diffhunk://#diff-b0c79c5aa41d89cac93f2f9ec9ce8b71a4e25efc0deb7f4a3dcd96d2dfe9b407R23-R25): Added code to ensure the creation of the `tests/Feature/SocialitePlus` directory and copy necessary files.

Code cleanup:

* [`src/SocialitePlusServiceProvider.php`](diffhunk://#diff-b268d10576543f0e7f9c30de09945a2f5427c99329ccb25b4c035d4f2797b075L32-L34): Removed redundant code that ensures the creation of the `tests/Feature/SocialitePlus` directory and copies necessary files, as this is now handled in the `installReact` and `installVue` methods.